### PR TITLE
Update tests to expect ggplot S3 class (fixes #1)

### DIFF
--- a/tests/testthat/test-plotmSdynamics.R
+++ b/tests/testthat/test-plotmSdynamics.R
@@ -1,6 +1,6 @@
 data(clr)
 test_that("plotmSdynamics output is a list for plotting a ggplot object", {
-  expect_type(plotmSdynamics(results = mSpreviz(results = iterativeClustering(pairedTimes = pairedTimes(data = clr, sequential = TRUE, common = "_0_"), 
+  expect_s3_class(plotmSdynamics(results = mSpreviz(results = iterativeClustering(pairedTimes = pairedTimes(data = clr, sequential = TRUE, common = "_0_"), 
                                                                           common = "_"),
                                             times = pairedTimes(data = clr, sequential = TRUE, common = "_0_")), 
                          groups = mSmetadataGroups(metadata = data.frame(Sample = rownames(clr), age = c(rep("youth", 65), rep("old", 131-65))), 
@@ -9,5 +9,5 @@ test_that("plotmSdynamics output is a list for plotting a ggplot object", {
                                                                                                         common = "_"),
                                                                           times = pairedTimes(data = clr, sequential = TRUE, common = "_0_"))$individual, 
                                                    variable = "age"), points = TRUE, linetype = 0),
-              "list")
+              "ggplot")
 })

--- a/tests/testthat/test-plotmSheatmap.R
+++ b/tests/testthat/test-plotmSheatmap.R
@@ -1,8 +1,8 @@
 data(clr)
 test_that("plotmSheatmap output is a list for plotting a ggplot object", {
-  expect_type(plotmSheatmap(results = mSpreviz(results = iterativeClustering(pairedTimes = pairedTimes(data = clr, sequential = TRUE, common = "_0_"), 
+  expect_s3_class(plotmSheatmap(results = mSpreviz(results = iterativeClustering(pairedTimes = pairedTimes(data = clr, sequential = TRUE, common = "_0_"), 
                                                                          common = "_"),
                                            times = pairedTimes(data = clr, sequential = TRUE, common = "_0_")),
                         order = "median", times = c("t1_t25", "t25_t26"),
-                        label = TRUE), "list")
+                        label = TRUE), "ggplot")
 })

--- a/tests/testthat/test-plotmSlinesCV.R
+++ b/tests/testthat/test-plotmSlinesCV.R
@@ -1,9 +1,9 @@
 data(clr)
 test_that("plotmSlineCV output is a list for plotting a ggplot object", {
-  expect_type(plotmSlinesCV(pairedTimes(data = clr, sequential = TRUE, common = "_0_")$t1_t25,
+  expect_s3_class(plotmSlinesCV(pairedTimes(data = clr, sequential = TRUE, common = "_0_")$t1_t25,
                         iterativeClusteringCV(pairedTimes = pairedTimes(data = clr, sequential = TRUE, common = "_0_"),
                                               results = iterativeClustering(pairedTimes = pairedTimes(data = clr, sequential = TRUE, common = "_0_"),
                                                                             common = "_"), name = "t1_t25",
                                               common = "_", k = 2L),
-                        k = 2L), "list")
+                        k = 2L), "ggplot")
 })

--- a/tests/testthat/test-plotmSscatter.R
+++ b/tests/testthat/test-plotmSscatter.R
@@ -1,8 +1,8 @@
 data(clr)
 test_that("plotmSscater output is a list for plotting a ggplot with ggside extension", {
-  expect_type(plotmSscatter(results = mSpreviz(results = iterativeClustering(pairedTimes = pairedTimes(data = clr, sequential = TRUE, common = "_0_"), 
+  expect_s3_class(plotmSscatter(results = mSpreviz(results = iterativeClustering(pairedTimes = pairedTimes(data = clr, sequential = TRUE, common = "_0_"), 
                                                                        common = "_"),
                                          times = pairedTimes(data = clr, sequential = TRUE, common = "_0_")),
                       order = "median", times = c("t1_t25", "t25_t26"),
-                      gridLines = TRUE, sideScale = 0.2), "list")
+                      gridLines = TRUE, sideScale = 0.2), "ggplot")
 })


### PR DESCRIPTION
Replace expect_type(..., "list") with expect_s3_class(..., "ggplot") in plotting tests because the plotting helpers return ggplot objects rather than plain lists. Updated tests: tests/testthat/test-plotmSdynamics.R, tests/testthat/test-plotmSheatmap.R, tests/testthat/test-plotmSlinesCV.R, tests/testthat/test-plotmSscatter.R to assert the correct S3 class.